### PR TITLE
Improvements to the info_auto PR

### DIFF
--- a/tactics/tacinterp.ml
+++ b/tactics/tacinterp.ml
@@ -2020,12 +2020,6 @@ and interp_atomic ist tac : unit Proofview.tactic =
 
   (* Automation tactics *)
   | TacTrivial (debug,lems,l) ->
-      begin if debug == Tacexpr.Info then
-          msg_warning
-	    (strbrk"The \"info_trivial\" tactic" ++ spc ()
-           ++strbrk"does not print traces anymore." ++ spc()
-           ++strbrk"Use \"Info 1 trivial\", instead.")
-      end;
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
         let sigma = Proofview.Goal.sigma gl in
@@ -2036,13 +2030,8 @@ and interp_atomic ist tac : unit Proofview.tactic =
 	     lems
 	     (Option.map (List.map (interp_hint_base ist)) l))
       end
+
   | TacAuto (debug,n,lems,l) ->
-      begin if debug == Tacexpr.Info then
-          msg_warning
-	    (strbrk"The \"info_auto\" tactic" ++ spc ()
-           ++strbrk"does not print traces anymore." ++ spc()
-           ++strbrk"Use \"Info 1 auto\", instead.")
-      end;
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
         let sigma = Proofview.Goal.sigma gl in


### PR DESCRIPTION
For now, I have pushed a first improvement which is to remove the warning.

I would like to remove the indentation as well if I find where it is defined.

Finally, I had a quick look to find about the different behavior of `info_auto` and `info_eauto` (one printing `assumption` and the other `exact H`). I'm starting to think that this difference might not just be in the printing but in the underlying implementation as well. If this is the case, maybe making everything uniform should wait the translation of `eauto` into the new proof engine.
If I'm right, could it be the case that this documentation of `auto`

> This tactic implements a Prolog-like resolution procedure to solve the current goal. It first tries to solve the goal using the assumption tactic, then it reduces the goal to an atomic one using intros and introduces the newly generated hypotheses as hints. Then it looks at the list of tactics associated to the head symbol of the goal and tries to apply one of them (starting from the tactics with lower cost). This process is recursively applied to the generated subgoals.

is now correct only for `eauto` (especially the part "introduces the newly generated hypotheses as hints")?
